### PR TITLE
Allow release notes URL to be specified when creating release

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,9 @@ release creation will fail.
   May contain line breaks.
   ```
 
+* `release_notes_url_file`: *Optional.* File containing the release notes URL
+  e.g. `http://url.to/release/notes`
+
 ## Developing
 
 ### Prerequisites

--- a/acceptance/in_test.go
+++ b/acceptance/in_test.go
@@ -78,6 +78,9 @@ var _ = Describe("In", func() {
 
 		_, err = metadataValueForKey(response.Metadata, "description")
 		Expect(err).ShouldNot(HaveOccurred())
+
+		_, err = metadataValueForKey(response.Metadata, "release_notes_url")
+		Expect(err).ShouldNot(HaveOccurred())
 	})
 
 	It("does not download any of the files in the specified release", func() {

--- a/acceptance/out_test.go
+++ b/acceptance/out_test.go
@@ -48,6 +48,9 @@ var _ = Describe("Out", func() {
 		descriptionFile = "description"
 		description     = "this release is for automated-testing only."
 
+		releaseNotesURLFile = "release_notes_url"
+		releaseNotesURL     = "http://zombo.com"
+
 		productSlug = "pivotal-diego-pcf"
 
 		command       *exec.Cmd
@@ -101,6 +104,13 @@ var _ = Describe("Out", func() {
 			os.ModePerm)
 		Expect(err).ShouldNot(HaveOccurred())
 
+		By("Writing release notes URL to file")
+		err = ioutil.WriteFile(
+			filepath.Join(rootDir, releaseNotesURLFile),
+			[]byte(releaseNotesURL),
+			os.ModePerm)
+		Expect(err).ShouldNot(HaveOccurred())
+
 		By("Creating command object")
 		command = exec.Command(outPath, rootDir)
 
@@ -113,13 +123,14 @@ var _ = Describe("Out", func() {
 				ProductSlug:     productSlug,
 			},
 			Params: concourse.OutParams{
-				FileGlob:        "*",
-				FilepathPrefix:  s3FilepathPrefix,
-				VersionFile:     productVersionFile,
-				ReleaseTypeFile: releaseTypeFile,
-				ReleaseDateFile: releaseDateFile,
-				EulaSlugFile:    eulaSlugFile,
-				DescriptionFile: descriptionFile,
+				FileGlob:            "*",
+				FilepathPrefix:      s3FilepathPrefix,
+				VersionFile:         productVersionFile,
+				ReleaseTypeFile:     releaseTypeFile,
+				ReleaseDateFile:     releaseDateFile,
+				EulaSlugFile:        eulaSlugFile,
+				DescriptionFile:     descriptionFile,
+				ReleaseNotesURLFile: releaseNotesURLFile,
 			},
 		}
 
@@ -340,6 +351,7 @@ var _ = Describe("Out", func() {
 			Expect(release.ReleaseDate).To(Equal(releaseDate))
 			Expect(release.Eula.Slug).To(Equal(eulaSlug))
 			Expect(release.Description).To(Equal(description))
+			Expect(release.ReleaseNotesURL).To(Equal(releaseNotesURL))
 
 			By("Validing the returned metadata")
 			metadataReleaseType, err := metadataValueForKey(response.Metadata, "release_type")
@@ -353,6 +365,10 @@ var _ = Describe("Out", func() {
 			metadataDescription, err := metadataValueForKey(response.Metadata, "description")
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(metadataDescription).To(Equal(description))
+
+			metadataReleaseNotesURL, err := metadataValueForKey(response.Metadata, "release_notes_url")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(metadataReleaseNotesURL).To(Equal(releaseNotesURL))
 		})
 
 		Context("when S3 source and params are configured correctly", func() {

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -158,6 +158,7 @@ func main() {
 			{Name: "release_type", Value: release.ReleaseType},
 			{Name: "release_date", Value: release.ReleaseDate},
 			{Name: "description", Value: release.Description},
+			{Name: "release_notes_url", Value: release.ReleaseNotesURL},
 			{Name: "eula_slug", Value: release.Eula.Slug},
 		},
 	}

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -92,12 +92,13 @@ func main() {
 	productSlug := input.Source.ProductSlug
 
 	config := pivnet.CreateReleaseConfig{
-		ProductSlug:    productSlug,
-		ReleaseType:    readStringContents(sourcesDir, input.Params.ReleaseTypeFile),
-		EulaSlug:       readStringContents(sourcesDir, input.Params.EulaSlugFile),
-		ProductVersion: readStringContents(sourcesDir, input.Params.VersionFile),
-		Description:    readStringContents(sourcesDir, input.Params.DescriptionFile),
-		ReleaseDate:    readStringContents(sourcesDir, input.Params.ReleaseDateFile),
+		ProductSlug:     productSlug,
+		ReleaseType:     readStringContents(sourcesDir, input.Params.ReleaseTypeFile),
+		EulaSlug:        readStringContents(sourcesDir, input.Params.EulaSlugFile),
+		ProductVersion:  readStringContents(sourcesDir, input.Params.VersionFile),
+		Description:     readStringContents(sourcesDir, input.Params.DescriptionFile),
+		ReleaseNotesURL: readStringContents(sourcesDir, input.Params.ReleaseNotesURLFile),
+		ReleaseDate:     readStringContents(sourcesDir, input.Params.ReleaseDateFile),
 	}
 
 	release, err := pivnetClient.CreateRelease(config)
@@ -184,6 +185,7 @@ func main() {
 			{Name: "release_type", Value: release.ReleaseType},
 			{Name: "release_date", Value: release.ReleaseDate},
 			{Name: "description", Value: release.Description},
+			{Name: "release_notes_url", Value: release.ReleaseNotesURL},
 			{Name: "eula_slug", Value: release.Eula.Slug},
 		},
 	}

--- a/concourse/types.go
+++ b/concourse/types.go
@@ -44,13 +44,14 @@ type OutRequest struct {
 }
 
 type OutParams struct {
-	FileGlob        string `json:"file_glob"`
-	FilepathPrefix  string `json:"s3_filepath_prefix"`
-	VersionFile     string `json:"version_file"`
-	ReleaseTypeFile string `json:"release_type_file"`
-	ReleaseDateFile string `json:"release_date_file"`
-	EulaSlugFile    string `json:"eula_slug_file"`
-	DescriptionFile string `json:"description_file"`
+	FileGlob            string `json:"file_glob"`
+	FilepathPrefix      string `json:"s3_filepath_prefix"`
+	VersionFile         string `json:"version_file"`
+	ReleaseTypeFile     string `json:"release_type_file"`
+	ReleaseDateFile     string `json:"release_date_file"`
+	EulaSlugFile        string `json:"eula_slug_file"`
+	DescriptionFile     string `json:"description_file"`
+	ReleaseNotesURLFile string `json:"release_notes_url_file"`
 }
 
 type OutResponse struct {

--- a/pivnet/releases.go
+++ b/pivnet/releases.go
@@ -13,12 +13,13 @@ type createReleaseBody struct {
 }
 
 type CreateReleaseConfig struct {
-	ProductSlug    string
-	ProductVersion string
-	ReleaseType    string
-	ReleaseDate    string
-	EulaSlug       string
-	Description    string
+	ProductSlug     string
+	ProductVersion  string
+	ReleaseType     string
+	ReleaseDate     string
+	EulaSlug        string
+	Description     string
+	ReleaseNotesURL string
 }
 
 func (c client) GetRelease(productSlug, version string) (Release, error) {
@@ -56,11 +57,12 @@ func (c client) CreateRelease(config CreateReleaseConfig) (Release, error) {
 			Eula: &Eula{
 				Slug: config.EulaSlug,
 			},
-			OSSCompliant: "confirm",
-			ReleaseDate:  config.ReleaseDate,
-			ReleaseType:  config.ReleaseType,
-			Version:      config.ProductVersion,
-			Description:  config.Description,
+			OSSCompliant:    "confirm",
+			ReleaseDate:     config.ReleaseDate,
+			ReleaseType:     config.ReleaseType,
+			Version:         config.ProductVersion,
+			Description:     config.Description,
+			ReleaseNotesURL: config.ReleaseNotesURL,
 		},
 	}
 

--- a/pivnet/releases_test.go
+++ b/pivnet/releases_test.go
@@ -233,6 +233,58 @@ var _ = Describe("PivnetClient - product files", func() {
 					})
 				})
 			})
+
+			Describe("optional release notes URL field", func() {
+				var (
+					releaseNotesURL string
+				)
+
+				Context("when the optional release notes URL field is present", func() {
+					BeforeEach(func() {
+						releaseNotesURL = "some releaseNotesURL"
+
+						createReleaseConfig.ReleaseNotesURL = releaseNotesURL
+						expectedRequestBody.Release.ReleaseNotesURL = releaseNotesURL
+					})
+
+					It("creates the release with the release notes URL field", func() {
+						server.AppendHandlers(
+							ghttp.CombineHandlers(
+								ghttp.VerifyRequest("POST", apiPrefix+"/products/"+productSlug+"/releases"),
+								ghttp.VerifyJSONRepresenting(&expectedRequestBody),
+								ghttp.RespondWith(http.StatusCreated, validResponse),
+							),
+						)
+
+						release, err := client.CreateRelease(createReleaseConfig)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(release.Version).To(Equal(productVersion))
+					})
+				})
+
+				Context("when the optional release notes URL field is not present", func() {
+					BeforeEach(func() {
+						releaseNotesURL = ""
+
+						createReleaseConfig.ReleaseNotesURL = releaseNotesURL
+						expectedRequestBody.Release.ReleaseNotesURL = releaseNotesURL
+					})
+
+					It("creates the release with an empty release notes URL field", func() {
+						server.AppendHandlers(
+							ghttp.CombineHandlers(
+								ghttp.VerifyRequest("POST", apiPrefix+"/products/"+productSlug+"/releases"),
+								ghttp.VerifyJSONRepresenting(&expectedRequestBody),
+								ghttp.RespondWith(http.StatusCreated, validResponse),
+							),
+						)
+
+						release, err := client.CreateRelease(createReleaseConfig)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(release.Version).To(Equal(productVersion))
+					})
+				})
+			})
 		})
 
 		Context("when the server responds with a non-201 status code", func() {

--- a/pivnet/types.go
+++ b/pivnet/types.go
@@ -13,15 +13,16 @@ type ProductFileResponse struct {
 }
 
 type Release struct {
-	ID           int    `json:"id,omitempty"`
-	Availability string `json:"availability,omitempty"`
-	Eula         *Eula  `json:"eula,omitempty"`
-	OSSCompliant string `json:"oss_compliant,omitempty"`
-	ReleaseDate  string `json:"release_date,omitempty"`
-	ReleaseType  string `json:"release_type,omitempty"`
-	Version      string `json:"version,omitempty"`
-	Links        *Links `json:"_links,omitempty"`
-	Description  string `json:"description,omitempty"`
+	ID              int    `json:"id,omitempty"`
+	Availability    string `json:"availability,omitempty"`
+	Eula            *Eula  `json:"eula,omitempty"`
+	OSSCompliant    string `json:"oss_compliant,omitempty"`
+	ReleaseDate     string `json:"release_date,omitempty"`
+	ReleaseType     string `json:"release_type,omitempty"`
+	Version         string `json:"version,omitempty"`
+	Links           *Links `json:"_links,omitempty"`
+	Description     string `json:"description,omitempty"`
+	ReleaseNotesURL string `json:"release_notes_url,omitempty"`
 }
 
 type Eula struct {


### PR DESCRIPTION
An optional field that would be nice to be able to set when creating a release.

All of the tests passed except for five acceptance tests, but they all looked like they were caused by my fake S3 credentials (I don't have credentials to really put things in S3 buckets).