### PR TITLE
Add support for release availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,10 @@ release creation will fail.
   - All Users
   - Selected User Groups Only
 
+* `user_group_ids_file`: *Optional.* File containing a comma-separated list of user
+  group IDs. Each user group in the list will be added to the release.
+  Will be read only if the availability is set to Selected User Groups Only.
+
 ## Developing
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -165,6 +165,12 @@ release creation will fail.
 * `release_notes_url_file`: *Optional.* File containing the release notes URL
   e.g. `http://url.to/release/notes`
 
+* `availability`: *Optional.* File containing the availability.
+  Will be read to determine the availability. Valid file contents are:
+  - Admins Only
+  - All Users
+  - Selected User Groups Only
+
 ## Developing
 
 ### Prerequisites

--- a/acceptance/acceptance_suite_test.go
+++ b/acceptance/acceptance_suite_test.go
@@ -182,6 +182,25 @@ func getProductFiles(productSlug string) []pivnet.ProductFile {
 	return response.ProductFiles
 }
 
+func getUserGroups(productSlug string, releaseID int) []pivnet.UserGroup {
+	user_groups_url := fmt.Sprintf("https://network.pivotal.io/api/v2/products/%s/releases/%d/user_groups", productSlug, releaseID)
+
+	req, err := http.NewRequest("GET", user_groups_url, nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	req.Header.Add("Authorization", fmt.Sprintf("Token %s", pivnetAPIToken))
+
+	resp, err := http.DefaultClient.Do(req)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+	response := pivnet.UserGroups{}
+	err = json.NewDecoder(resp.Body).Decode(&response)
+	Expect(err).NotTo(HaveOccurred())
+
+	return response.UserGroups
+}
+
 // copyFileContents copies the contents of the file named src to the file named
 // by dst. The file will be created if it does not already exist. If the
 // destination file exists, all it's contents will be replaced by the contents

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -177,6 +177,18 @@ func main() {
 		}
 	}
 
+	availability := readStringContents(sourcesDir, input.Params.AvailabilityFile)
+	if availability != "Admins Only" {
+		releaseUpdate := pivnet.Release{
+			ID:           release.ID,
+			Availability: availability,
+		}
+		release, err = pivnetClient.UpdateRelease(productSlug, releaseUpdate)
+		if err != nil {
+			log.Fatalln(err)
+		}
+	}
+
 	out := concourse.OutResponse{
 		Version: concourse.Version{
 			ProductVersion: release.Version,
@@ -187,6 +199,7 @@ func main() {
 			{Name: "description", Value: release.Description},
 			{Name: "release_notes_url", Value: release.ReleaseNotesURL},
 			{Name: "eula_slug", Value: release.Eula.Slug},
+			{Name: "availability", Value: release.Availability},
 		},
 	}
 

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -7,6 +7,8 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 
 	"github.com/pivotal-cf-experimental/pivnet-resource/concourse"
 	"github.com/pivotal-cf-experimental/pivnet-resource/logger"
@@ -186,6 +188,18 @@ func main() {
 		release, err = pivnetClient.UpdateRelease(productSlug, releaseUpdate)
 		if err != nil {
 			log.Fatalln(err)
+		}
+
+		if availability == "Selected User Groups Only" {
+			userGroupIDs := strings.Split(readStringContents(sourcesDir, input.Params.UserGroupIDsFile), ",")
+			for _, userGroupIDString := range userGroupIDs {
+				userGroupID, err := strconv.Atoi(userGroupIDString)
+				if err != nil {
+					log.Fatalln(err)
+				}
+
+				pivnetClient.AddUserGroup(productSlug, release.ID, userGroupID)
+			}
 		}
 	}
 

--- a/concourse/types.go
+++ b/concourse/types.go
@@ -53,6 +53,7 @@ type OutParams struct {
 	DescriptionFile     string `json:"description_file"`
 	ReleaseNotesURLFile string `json:"release_notes_url_file"`
 	AvailabilityFile    string `json:"availability_file"`
+	UserGroupIDsFile    string `json:"user_group_ids_file"`
 }
 
 type OutResponse struct {

--- a/concourse/types.go
+++ b/concourse/types.go
@@ -52,6 +52,7 @@ type OutParams struct {
 	EulaSlugFile        string `json:"eula_slug_file"`
 	DescriptionFile     string `json:"description_file"`
 	ReleaseNotesURLFile string `json:"release_notes_url_file"`
+	AvailabilityFile    string `json:"availability_file"`
 }
 
 type OutResponse struct {

--- a/pivnet/pivnet_client.go
+++ b/pivnet/pivnet_client.go
@@ -20,7 +20,7 @@ type Client interface {
 	ProductVersions(string) ([]string, error)
 	CreateRelease(config CreateReleaseConfig) (Release, error)
 	GetRelease(string, string) (Release, error)
-	UpdateRelease(string, Release) error
+	UpdateRelease(string, Release) (Release, error)
 	GetProductFiles(Release) (ProductFiles, error)
 	AcceptEULA(productSlug string, releaseID int) error
 	CreateProductFile(config CreateProductFileConfig) (ProductFile, error)

--- a/pivnet/pivnet_client.go
+++ b/pivnet/pivnet_client.go
@@ -25,8 +25,9 @@ type Client interface {
 	AcceptEULA(productSlug string, releaseID int) error
 	CreateProductFile(config CreateProductFileConfig) (ProductFile, error)
 	DeleteProductFile(productSlug string, id int) (ProductFile, error)
-	AddProductFile(productId int, releaseID int, productFileID int) error
+	AddProductFile(productID int, releaseID int, productFileID int) error
 	FindProductForSlug(slug string) (Product, error)
+	AddUserGroup(productSlug string, releaseID int, userGroupID int) error
 }
 
 type client struct {

--- a/pivnet/product_files_test.go
+++ b/pivnet/product_files_test.go
@@ -242,7 +242,7 @@ var _ = Describe("PivnetClient - product files", func() {
 			})
 		})
 
-		Context("when the server responds with a non-201 status code", func() {
+		Context("when the server responds with a non-204 status code", func() {
 			It("returns an error", func() {
 				server.AppendHandlers(
 					ghttp.CombineHandlers(

--- a/pivnet/releases.go
+++ b/pivnet/releases.go
@@ -88,8 +88,10 @@ func (c client) CreateRelease(config CreateReleaseConfig) (Release, error) {
 	return response.Release, nil
 }
 
-func (c client) UpdateRelease(productSlug string, release Release) error {
+func (c client) UpdateRelease(productSlug string, release Release) (Release, error) {
 	url := fmt.Sprintf("%s/products/%s/releases/%d", c.url, productSlug, release.ID)
+
+	release.OSSCompliant = "confirm"
 
 	var updatedRelease = createReleaseBody{
 		Release: release,
@@ -100,10 +102,11 @@ func (c client) UpdateRelease(productSlug string, release Release) error {
 		panic(err)
 	}
 
-	err = c.makeRequest("PATCH", url, http.StatusOK, bytes.NewReader(body), nil)
+	var response CreateReleaseResponse
+	err = c.makeRequest("PATCH", url, http.StatusOK, bytes.NewReader(body), &response)
 	if err != nil {
-		return err
+		return Release{}, err
 	}
 
-	return nil
+	return response.Release, nil
 }

--- a/pivnet/types.go
+++ b/pivnet/types.go
@@ -62,3 +62,13 @@ type Product struct {
 	ID   int    `json:"id,omitempty"`
 	Slug string `json:"slug"`
 }
+
+type UserGroups struct {
+	UserGroups []UserGroup `json:"user_groups,omitempty"`
+}
+
+type UserGroup struct {
+	ID          int    `json:"id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+}

--- a/pivnet/user_groups.go
+++ b/pivnet/user_groups.go
@@ -1,0 +1,49 @@
+package pivnet
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+type addUserGroupBody struct {
+	UserGroup UserGroup `json:"user_group"`
+}
+
+func (c client) AddUserGroup(
+	productSlug string,
+	releaseID int,
+	userGroupID int,
+) error {
+	url := fmt.Sprintf(
+		"%s/products/%s/releases/%d/add_user_group",
+		c.url,
+		productSlug,
+		releaseID,
+	)
+
+	body := addUserGroupBody{
+		UserGroup: UserGroup{
+			ID: userGroupID,
+		},
+	}
+
+	b, err := json.Marshal(body)
+	if err != nil {
+		panic(err)
+	}
+
+	err = c.makeRequest(
+		"PATCH",
+		url,
+		http.StatusNoContent,
+		bytes.NewReader(b),
+		nil,
+	)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pivnet/user_groups_test.go
+++ b/pivnet/user_groups_test.go
@@ -1,0 +1,96 @@
+package pivnet_test
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	"github.com/pivotal-cf-experimental/pivnet-resource/logger"
+	logger_fakes "github.com/pivotal-cf-experimental/pivnet-resource/logger/fakes"
+	"github.com/pivotal-cf-experimental/pivnet-resource/pivnet"
+)
+
+var _ = Describe("PivnetClient - user groups", func() {
+	var (
+		server     *ghttp.Server
+		client     pivnet.Client
+		token      string
+		apiAddress string
+		userAgent  string
+
+		newClientConfig pivnet.NewClientConfig
+		fakeLogger      logger.Logger
+	)
+
+	BeforeEach(func() {
+		server = ghttp.NewServer()
+		apiAddress = server.URL() + apiPrefix
+		token = "my-auth-token"
+		userAgent = "pivnet-resource/0.1.0 (some-url)"
+
+		fakeLogger = &logger_fakes.FakeLogger{}
+		newClientConfig = pivnet.NewClientConfig{
+			URL:       apiAddress,
+			Token:     token,
+			UserAgent: userAgent,
+		}
+		client = pivnet.NewClient(newClientConfig, fakeLogger)
+	})
+
+	AfterEach(func() {
+		server.Close()
+	})
+
+	Describe("Add User Group", func() {
+		var (
+			productSlug = "banana-slug"
+			releaseID   = 2345
+			userGroupID = 3456
+
+			expectedRequestBody = `{"user_group":{"id":3456}}`
+		)
+
+		Context("when the server responds with a 204 status code", func() {
+			It("returns without error", func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("PATCH", fmt.Sprintf(
+							"%s/products/%s/releases/%d/add_user_group",
+							apiPrefix,
+							productSlug,
+							releaseID,
+						)),
+						ghttp.VerifyJSON(expectedRequestBody),
+						ghttp.RespondWith(http.StatusNoContent, nil),
+					),
+				)
+
+				err := client.AddUserGroup(productSlug, releaseID, userGroupID)
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		Context("when the server responds with a non-204 status code", func() {
+			It("returns an error", func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("PATCH", fmt.Sprintf(
+							"%s/products/%s/releases/%d/add_user_group",
+							apiPrefix,
+							productSlug,
+							releaseID,
+						)),
+						ghttp.RespondWith(http.StatusTeapot, nil),
+					),
+				)
+
+				err := client.AddUserGroup(productSlug, releaseID, userGroupID)
+				Expect(err).To(MatchError(errors.New(
+					"Pivnet returned status code: 418 for the request - expected 204")))
+			})
+		})
+	})
+})


### PR DESCRIPTION
This change adds support for specifying an availability other than "Admins Only" for newly created releases. Currently when creating a new release via the Pivnet API, the availability must be set to "Admins Only." It can then be changed with a PATCH request. Additionally, if you want to set the availability to "Selected User Groups Only" and associate some user groups with the release, you must make a PATCH for each group using the group's ID.

I changed the UpdateRelease function on the client to return the release that is returned by the Pivnet API, similar to CreateRelease. It also sets OSSCompliant to "confirm" which must be set every time a release is updated. This prevents the caller to have to remember to add it to their release before calling UpdateRelease (since the responses from POST and PATCH release don't include "oss_compliant": "confirm").

I wasn't quite sure what the best way to pass in groups would be. A file with a comma-separated list of group IDs seemed like an easy solution and pretty consistent with the rest of the interface, but I'm definitely open to other ideas.