### PR TITLE
Do not wrap file in bufio.Reader in md5 summer

### DIFF
--- a/md5/md5.go
+++ b/md5/md5.go
@@ -1,7 +1,6 @@
 package md5
 
 import (
-	"bufio"
 	"crypto/md5"
 	"fmt"
 	"io"
@@ -31,9 +30,8 @@ func (f fileContentsSummer) Sum() (string, error) {
 	}
 	defer fileToSum.Close()
 
-	fileReader := bufio.NewReader(fileToSum)
 	hash := md5.New()
-	_, err = io.Copy(hash, fileReader)
+	_, err = io.Copy(hash, fileToSum)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
bufio.Reader adds nothing and makes it slightly slower.

@zachgersh you were right. I did some testing with a 4G file and passing the File to io.Copy was the fastest.