### PR TITLE
Added product_version_only mode to exclude fingerprint and perform version-only check

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ resources:
 
   Empty values match all product versions.
 
+* `product_version_only`: *Optional boolean.*
+
+  When `true`, the resource triggers only when a new product version is released. Changes to metadata or to the software-files updated timestamp for the same version do not trigger a new version. The version passed to `get` is the product version only (no fingerprint). Defaults to `false`; when `false`, the resource uses version and fingerprint so that metadata-only updates can trigger (see `sort_by: last_updated`).
+
 * `sort_by`: *Optional string.*
 
   Order to use for sorting releases. One of the following:

--- a/check/check_command.go
+++ b/check/check_command.go
@@ -114,7 +114,8 @@ func (c *CheckCommand) Run(input concourse.CheckRequest) (concourse.CheckRespons
 		}
 	}
 
-	vs, err := releaseVersions(releases)
+	productVersionOnly := input.Source.ProductVersionOnly
+	vs, err := releaseVersions(releases, productVersionOnly)
 	if err != nil {
 		// Untested because versions.CombineVersionAndFingerprint cannot be forced to return an error.
 		return concourse.CheckResponse{}, err
@@ -126,7 +127,11 @@ func (c *CheckCommand) Run(input concourse.CheckRequest) (concourse.CheckRespons
 
 	c.logger.Info("Gathering new versions")
 
-	newVersions, err := versions.Since(vs, input.Version.ProductVersion)
+	sinceVersion := input.Version.ProductVersion
+	if productVersionOnly {
+		sinceVersion = versions.VersionOnly(sinceVersion)
+	}
+	newVersions, err := versions.Since(vs, sinceVersion)
 	if err != nil {
 		// Untested because versions.Since cannot be forced to return an error.
 		return nil, err
@@ -213,9 +218,21 @@ func containsString(strings []string, str string) bool {
 	return false
 }
 
-func releaseVersions(releases []pivnet.Release) ([]string, error) {
-	releaseVersions := make([]string, len(releases))
+func releaseVersions(releases []pivnet.Release, productVersionOnly bool) ([]string, error) {
+	if productVersionOnly {
+		seen := make(map[string]bool)
+		var result []string
+		for _, r := range releases {
+			if seen[r.Version] {
+				continue
+			}
+			seen[r.Version] = true
+			result = append(result, r.Version)
+		}
+		return result, nil
+	}
 
+	releaseVersions := make([]string, len(releases))
 	var err error
 	for i, r := range releases {
 		releaseVersions[i], err = versions.CombineVersionAndFingerprint(r.Version, r.SoftwareFilesUpdatedAt)

--- a/check/check_command_test.go
+++ b/check/check_command_test.go
@@ -447,4 +447,75 @@ var _ = Describe("Check", func() {
 			})
 		})
 	})
+
+	Context("when product_version_only is true", func() {
+		BeforeEach(func() {
+			checkRequest.Source.ProductVersionOnly = true
+
+			checkRequest.Source.SortBy = concourse.SortBySemver
+			fakeSorter.SortBySemverReturns([]pivnet.Release{
+				allReleases[1], // 2.3.4
+				allReleases[2], // 1.2.4
+				allReleases[0], // 1.2.3
+			}, nil)
+		})
+
+		It("returns only product versions without fingerprint", func() {
+			// Set "since" to oldest version so Since() returns all 3 versions (otherwise empty version returns only latest)
+			checkRequest.Version = concourse.Version{ProductVersion: "1.2.3"}
+
+			response, err := checkCommand.Run(checkRequest)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(response).To(HaveLen(3))
+			// Reverse() returns oldest-first: 1.2.3, 1.2.4, 2.3.4
+			Expect(response[0].ProductVersion).To(Equal("1.2.3"))
+			Expect(response[1].ProductVersion).To(Equal("1.2.4"))
+			Expect(response[2].ProductVersion).To(Equal("2.3.4"))
+		})
+
+		It("compares since using version only when current version has fingerprint", func() {
+			checkRequest.Version = concourse.Version{
+				ProductVersion: "1.2.3#time1",
+			}
+
+			response, err := checkCommand.Run(checkRequest)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Should return 1.2.3 and newer (1.2.4, 2.3.4); VersionOnly("1.2.3#time1") = "1.2.3" so all 3 returned. Reverse gives oldest-first.
+			Expect(response).To(HaveLen(3))
+			Expect(response[0].ProductVersion).To(Equal("1.2.3"))
+			Expect(response[1].ProductVersion).To(Equal("1.2.4"))
+			Expect(response[2].ProductVersion).To(Equal("2.3.4"))
+		})
+
+		Context("when multiple releases have the same product version", func() {
+			BeforeEach(func() {
+				releasesWithDuplicateVersion := []pivnet.Release{
+					{ID: 1, Version: "1.2.3", SoftwareFilesUpdatedAt: "time1"},
+					{ID: 2, Version: "1.2.3", SoftwareFilesUpdatedAt: "time2"},
+					{ID: 3, Version: "2.0.0", SoftwareFilesUpdatedAt: "time3"},
+				}
+				allReleases = releasesWithDuplicateVersion
+				filteredReleases = releasesWithDuplicateVersion
+				fakePivnetClient.ReleasesForProductSlugReturns(releasesWithDuplicateVersion, nil)
+				fakeFilter.ReleasesByReleaseTypeReturns(releasesWithDuplicateVersion, nil)
+				fakeFilter.ReleasesByVersionReturns(releasesWithDuplicateVersion, nil)
+				fakeSorter.SortBySemverReturns(releasesWithDuplicateVersion, nil)
+			})
+
+			It("deduplicates by product version and returns one entry per version", func() {
+				// Set "since" to newest (2.0.0) so Since() returns both versions [1.2.3, 2.0.0]; Reverse gives newest-first
+				checkRequest.Version = concourse.Version{ProductVersion: "2.0.0"}
+
+				response, err := checkCommand.Run(checkRequest)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(response).To(HaveLen(2))
+				// vs = ["1.2.3", "2.0.0"] (deduped), Since(..., "2.0.0") -> ["1.2.3","2.0.0"], Reverse -> ["2.0.0","1.2.3"]
+				Expect(response[0].ProductVersion).To(Equal("2.0.0"))
+				Expect(response[1].ProductVersion).To(Equal("1.2.3"))
+			})
+		})
+	})
 })

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -269,6 +269,7 @@ func main() {
 		m,
 		sourcesDir,
 		input.Source.ProductSlug,
+		input.Source.ProductVersionOnly,
 	)
 
 	outCmd := out.NewOutCommand(out.OutCommandConfig{

--- a/concourse/types.go
+++ b/concourse/types.go
@@ -9,15 +9,16 @@ const (
 )
 
 type Source struct {
-	APIToken          string `json:"api_token"`
-	ProductSlug       string `json:"product_slug"`
-	ProductVersion    string `json:"product_version"`
-	Endpoint          string `json:"endpoint"`
-	ReleaseType       string `json:"release_type"`
-	SortBy            SortBy `json:"sort_by"`
-	SkipSSLValidation bool   `json:"skip_ssl_verification"`
-	CopyMetadata      bool   `json:"copy_metadata"`
-	Verbose           bool   `json:"verbose"`
+	APIToken           string `json:"api_token"`
+	ProductSlug        string `json:"product_slug"`
+	ProductVersion     string `json:"product_version"`
+	Endpoint           string `json:"endpoint"`
+	ReleaseType        string `json:"release_type"`
+	SortBy             SortBy `json:"sort_by"`
+	SkipSSLValidation  bool   `json:"skip_ssl_verification"`
+	CopyMetadata       bool   `json:"copy_metadata"`
+	ProductVersionOnly bool   `json:"product_version_only"`
+	Verbose            bool   `json:"verbose"`
 }
 
 type CheckRequest struct {

--- a/out/release/release_finalizer.go
+++ b/out/release/release_finalizer.go
@@ -11,12 +11,13 @@ import (
 )
 
 type ReleaseFinalizer struct {
-	logger      logger.Logger
-	pivnet      finalizerClient
-	metadata    metadata.Metadata
-	params      concourse.OutParams
-	sourcesDir  string
-	productSlug string
+	logger             logger.Logger
+	pivnet             finalizerClient
+	metadata           metadata.Metadata
+	params             concourse.OutParams
+	sourcesDir         string
+	productSlug        string
+	productVersionOnly bool
 }
 
 func NewFinalizer(
@@ -26,14 +27,16 @@ func NewFinalizer(
 	metadata metadata.Metadata,
 	sourcesDir,
 	productSlug string,
+	productVersionOnly bool,
 ) ReleaseFinalizer {
 	return ReleaseFinalizer{
-		pivnet:      pivnetClient,
-		logger:      logger,
-		params:      params,
-		metadata:    metadata,
-		sourcesDir:  sourcesDir,
-		productSlug: productSlug,
+		pivnet:             pivnetClient,
+		logger:             logger,
+		params:             params,
+		metadata:           metadata,
+		sourcesDir:         sourcesDir,
+		productSlug:        productSlug,
+		productVersionOnly: productVersionOnly,
 	}
 }
 
@@ -48,9 +51,15 @@ func (rf ReleaseFinalizer) Finalize(productSlug string, releaseVersion string) (
 		return concourse.OutResponse{}, err
 	}
 
-	outputVersion, err := versions.CombineVersionAndFingerprint(newRelease.Version, newRelease.SoftwareFilesUpdatedAt)
-	if err != nil {
-		return concourse.OutResponse{}, err // this will never return an error
+	var outputVersion string
+	if rf.productVersionOnly {
+		outputVersion = newRelease.Version
+	} else {
+		var err error
+		outputVersion, err = versions.CombineVersionAndFingerprint(newRelease.Version, newRelease.SoftwareFilesUpdatedAt)
+		if err != nil {
+			return concourse.OutResponse{}, err // this will never return an error
+		}
 	}
 
 	metadata := []concourse.Metadata{

--- a/out/release/release_finalizer_test.go
+++ b/out/release/release_finalizer_test.go
@@ -26,8 +26,9 @@ var _ = Describe("ReleaseFinalizer", func() {
 
 			mdata metadata.Metadata
 
-			productSlug   string
-			pivnetRelease pivnet.Release
+			productSlug        string
+			productVersionOnly bool
+			pivnetRelease      pivnet.Release
 
 			releaseErr error
 
@@ -43,6 +44,7 @@ var _ = Describe("ReleaseFinalizer", func() {
 			params = concourse.OutParams{}
 
 			productSlug = "some-product-slug"
+			productVersionOnly = false
 
 			pivnetRelease = pivnet.Release{
 				Availability: "Admins Only",
@@ -74,12 +76,13 @@ var _ = Describe("ReleaseFinalizer", func() {
 				mdata,
 				"/some/sources/dir",
 				productSlug,
+				productVersionOnly,
 			)
 
 			fakePivnet.GetReleaseReturns(pivnetRelease, releaseErr)
 		})
 
-		It("returns a final concourse out response", func() {
+		It("returns a final concourse out response with version and fingerprint", func() {
 			response, err := finalizer.Finalize(productSlug, pivnetRelease.Version)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -90,6 +93,21 @@ var _ = Describe("ReleaseFinalizer", func() {
 			Expect(response.Metadata).To(ContainElement(concourse.Metadata{Name: "version", Value: "some-version"}))
 			Expect(response.Metadata).To(ContainElement(concourse.Metadata{Name: "controlled", Value: "false"}))
 			Expect(response.Metadata).To(ContainElement(concourse.Metadata{Name: "eula_slug", Value: "a_eula_slug"}))
+		})
+
+		Context("when product_version_only is true", func() {
+			BeforeEach(func() {
+				productVersionOnly = true
+			})
+
+			It("returns version without fingerprint", func() {
+				response, err := finalizer.Finalize(productSlug, pivnetRelease.Version)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(response.Version).To(Equal(concourse.Version{
+					ProductVersion: "some-version",
+				}))
+			})
 		})
 
 		Context("when getting the release returns an error", func() {

--- a/versions/versions.go
+++ b/versions/versions.go
@@ -46,3 +46,10 @@ func CombineVersionAndFingerprint(version string, fingerprint string) (string, e
 func combineVersionAndFingerprint(version string, fingerprint string) string {
 	return fmt.Sprintf("%s%s%s", version, fingerprintDelimiter, fingerprint)
 }
+
+// VersionOnly returns the product version part of a version string, stripping any
+// fingerprint after the delimiter. If there is no delimiter, the full string is returned.
+func VersionOnly(versionWithOptionalFingerprint string) string {
+	split := strings.SplitN(versionWithOptionalFingerprint, fingerprintDelimiter, 2)
+	return split[0]
+}

--- a/versions/versions_test.go
+++ b/versions/versions_test.go
@@ -144,4 +144,18 @@ var _ = Describe("Versions", func() {
 			})
 		})
 	})
+
+	Describe("VersionOnly", func() {
+		It("returns only the version part when fingerprint is present", func() {
+			Expect(versions.VersionOnly("1.2.3#2024-01-15T12:00:00Z")).To(Equal("1.2.3"))
+		})
+
+		It("returns the full string when no delimiter is present", func() {
+			Expect(versions.VersionOnly("1.2.3")).To(Equal("1.2.3"))
+		})
+
+		It("returns the version part when fingerprint contains the delimiter", func() {
+			Expect(versions.VersionOnly("1.2.3#fingerprint-with#hash")).To(Equal("1.2.3"))
+		})
+	})
 })


### PR DESCRIPTION
Make the Pivnet resource trigger only when a **new product version** is released, and **not** when only metadata or `SoftwareFilesUpdatedAt` changes for the same version.