### PR TITLE
Use file-based fingerprint so resource only triggers when product files change

### DIFF
--- a/check/check_command.go
+++ b/check/check_command.go
@@ -28,6 +28,8 @@ type sorter interface {
 type pivnetClient interface {
 	ReleaseTypes() ([]pivnet.ReleaseType, error)
 	ReleasesForProductSlug(string) ([]pivnet.Release, error)
+	ProductFilesForRelease(productSlug string, releaseID int) ([]pivnet.ProductFile, error)
+	FileGroupsForRelease(productSlug string, releaseID int) ([]pivnet.FileGroup, error)
 }
 
 type CheckCommand struct {
@@ -114,7 +116,7 @@ func (c *CheckCommand) Run(input concourse.CheckRequest) (concourse.CheckRespons
 		}
 	}
 
-	vs, err := releaseVersions(releases)
+	vs, err := c.releaseVersions(productSlug, releases)
 	if err != nil {
 		// Untested because versions.CombineVersionAndFingerprint cannot be forced to return an error.
 		return concourse.CheckResponse{}, err
@@ -213,16 +215,53 @@ func containsString(strings []string, str string) bool {
 	return false
 }
 
-func releaseVersions(releases []pivnet.Release) ([]string, error) {
+func (c *CheckCommand) releaseVersions(productSlug string, releases []pivnet.Release) ([]string, error) {
 	releaseVersions := make([]string, len(releases))
 
-	var err error
 	for i, r := range releases {
-		releaseVersions[i], err = versions.CombineVersionAndFingerprint(r.Version, r.SoftwareFilesUpdatedAt)
+		allFiles, err := c.allProductFilesForRelease(productSlug, r.ID)
+		if err != nil {
+			return nil, err
+		}
+		fileMetadata := make([]versions.FileMetadata, 0, len(allFiles))
+		for _, pf := range allFiles {
+			fileMetadata = append(fileMetadata, versions.FileMetadata{ID: pf.ID, ReleasedAt: pf.ReleasedAt})
+		}
+		fingerprint := versions.FingerprintFromFileMetadata(fileMetadata)
+		releaseVersions[i], err = versions.CombineVersionAndFingerprint(r.Version, fingerprint)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	return releaseVersions, nil
+}
+
+// allProductFilesForRelease returns release product files plus file group product files (deduped by ID).
+func (c *CheckCommand) allProductFilesForRelease(productSlug string, releaseID int) ([]pivnet.ProductFile, error) {
+	releaseProductFiles, err := c.pivnetClient.ProductFilesForRelease(productSlug, releaseID)
+	if err != nil {
+		return nil, err
+	}
+	fileGroups, err := c.pivnetClient.FileGroupsForRelease(productSlug, releaseID)
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[int]bool)
+	var all []pivnet.ProductFile
+	for _, pf := range releaseProductFiles {
+		if !seen[pf.ID] {
+			seen[pf.ID] = true
+			all = append(all, pf)
+		}
+	}
+	for _, fg := range fileGroups {
+		for _, pf := range fg.ProductFiles {
+			if !seen[pf.ID] {
+				seen[pf.ID] = true
+				all = append(all, pf)
+			}
+		}
+	}
+	return all, nil
 }

--- a/check/check_command_test.go
+++ b/check/check_command_test.go
@@ -86,9 +86,12 @@ var _ = Describe("Check", func() {
 			},
 		}
 
+		// Compute expected versions from file-based fingerprint (TNZ-22056)
 		versionsWithFingerprints = make([]string, len(allReleases))
 		for i, r := range allReleases {
-			v, err := versions.CombineVersionAndFingerprint(r.Version, r.SoftwareFilesUpdatedAt)
+			fileMetadata := []versions.FileMetadata{{ID: r.ID, ReleasedAt: r.SoftwareFilesUpdatedAt}}
+			fingerprint := versions.FingerprintFromFileMetadata(fileMetadata)
+			v, err := versions.CombineVersionAndFingerprint(r.Version, fingerprint)
 			Expect(err).NotTo(HaveOccurred())
 			versionsWithFingerprints[i] = v
 		}
@@ -114,6 +117,16 @@ var _ = Describe("Check", func() {
 	JustBeforeEach(func() {
 		fakePivnetClient.ReleaseTypesReturns(releaseTypes, releaseTypesErr)
 		fakePivnetClient.ReleasesForProductSlugReturns(allReleases, releasesErr)
+		// Stub product files and file groups for file-based fingerprint (TNZ-22056)
+		fakePivnetClient.ProductFilesForReleaseStub = func(_ string, releaseID int) ([]pivnet.ProductFile, error) {
+			for _, r := range allReleases {
+				if r.ID == releaseID {
+					return []pivnet.ProductFile{{ID: r.ID, ReleasedAt: r.SoftwareFilesUpdatedAt}}, nil
+				}
+			}
+			return nil, nil
+		}
+		fakePivnetClient.FileGroupsForReleaseReturns([]pivnet.FileGroup{}, nil)
 
 		fakeFilter.ReleasesByReleaseTypeReturns(filteredReleases, releasesByReleaseTypeErr)
 		fakeFilter.ReleasesByVersionReturns(filteredReleases, releasesByVersionErr)
@@ -214,6 +227,18 @@ var _ = Describe("Check", func() {
 			Expect(err).To(HaveOccurred())
 
 			Expect(err.Error()).To(ContainSubstring("some error"))
+		})
+	})
+
+	Context("when there is an error getting product files for a release", func() {
+		BeforeEach(func() {
+			fakePivnetClient.ProductFilesForReleaseReturns(nil, fmt.Errorf("product files error"))
+		})
+
+		It("returns an error", func() {
+			_, err := checkCommand.Run(checkRequest)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("product files error"))
 		})
 	})
 

--- a/check/checkfakes/fake_pivnet_client.go
+++ b/check/checkfakes/fake_pivnet_client.go
@@ -8,6 +8,34 @@ import (
 )
 
 type FakePivnetClient struct {
+	FileGroupsForReleaseStub        func(string, int) ([]pivnet.FileGroup, error)
+	fileGroupsForReleaseMutex       sync.RWMutex
+	fileGroupsForReleaseArgsForCall []struct {
+		arg1 string
+		arg2 int
+	}
+	fileGroupsForReleaseReturns struct {
+		result1 []pivnet.FileGroup
+		result2 error
+	}
+	fileGroupsForReleaseReturnsOnCall map[int]struct {
+		result1 []pivnet.FileGroup
+		result2 error
+	}
+	ProductFilesForReleaseStub        func(string, int) ([]pivnet.ProductFile, error)
+	productFilesForReleaseMutex       sync.RWMutex
+	productFilesForReleaseArgsForCall []struct {
+		arg1 string
+		arg2 int
+	}
+	productFilesForReleaseReturns struct {
+		result1 []pivnet.ProductFile
+		result2 error
+	}
+	productFilesForReleaseReturnsOnCall map[int]struct {
+		result1 []pivnet.ProductFile
+		result2 error
+	}
 	ReleaseTypesStub        func() ([]pivnet.ReleaseType, error)
 	releaseTypesMutex       sync.RWMutex
 	releaseTypesArgsForCall []struct {
@@ -35,6 +63,136 @@ type FakePivnetClient struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakePivnetClient) FileGroupsForRelease(arg1 string, arg2 int) ([]pivnet.FileGroup, error) {
+	fake.fileGroupsForReleaseMutex.Lock()
+	ret, specificReturn := fake.fileGroupsForReleaseReturnsOnCall[len(fake.fileGroupsForReleaseArgsForCall)]
+	fake.fileGroupsForReleaseArgsForCall = append(fake.fileGroupsForReleaseArgsForCall, struct {
+		arg1 string
+		arg2 int
+	}{arg1, arg2})
+	stub := fake.FileGroupsForReleaseStub
+	fakeReturns := fake.fileGroupsForReleaseReturns
+	fake.recordInvocation("FileGroupsForRelease", []interface{}{arg1, arg2})
+	fake.fileGroupsForReleaseMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakePivnetClient) FileGroupsForReleaseCallCount() int {
+	fake.fileGroupsForReleaseMutex.RLock()
+	defer fake.fileGroupsForReleaseMutex.RUnlock()
+	return len(fake.fileGroupsForReleaseArgsForCall)
+}
+
+func (fake *FakePivnetClient) FileGroupsForReleaseCalls(stub func(string, int) ([]pivnet.FileGroup, error)) {
+	fake.fileGroupsForReleaseMutex.Lock()
+	defer fake.fileGroupsForReleaseMutex.Unlock()
+	fake.FileGroupsForReleaseStub = stub
+}
+
+func (fake *FakePivnetClient) FileGroupsForReleaseArgsForCall(i int) (string, int) {
+	fake.fileGroupsForReleaseMutex.RLock()
+	defer fake.fileGroupsForReleaseMutex.RUnlock()
+	argsForCall := fake.fileGroupsForReleaseArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakePivnetClient) FileGroupsForReleaseReturns(result1 []pivnet.FileGroup, result2 error) {
+	fake.fileGroupsForReleaseMutex.Lock()
+	defer fake.fileGroupsForReleaseMutex.Unlock()
+	fake.FileGroupsForReleaseStub = nil
+	fake.fileGroupsForReleaseReturns = struct {
+		result1 []pivnet.FileGroup
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakePivnetClient) FileGroupsForReleaseReturnsOnCall(i int, result1 []pivnet.FileGroup, result2 error) {
+	fake.fileGroupsForReleaseMutex.Lock()
+	defer fake.fileGroupsForReleaseMutex.Unlock()
+	fake.FileGroupsForReleaseStub = nil
+	if fake.fileGroupsForReleaseReturnsOnCall == nil {
+		fake.fileGroupsForReleaseReturnsOnCall = make(map[int]struct {
+			result1 []pivnet.FileGroup
+			result2 error
+		})
+	}
+	fake.fileGroupsForReleaseReturnsOnCall[i] = struct {
+		result1 []pivnet.FileGroup
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakePivnetClient) ProductFilesForRelease(arg1 string, arg2 int) ([]pivnet.ProductFile, error) {
+	fake.productFilesForReleaseMutex.Lock()
+	ret, specificReturn := fake.productFilesForReleaseReturnsOnCall[len(fake.productFilesForReleaseArgsForCall)]
+	fake.productFilesForReleaseArgsForCall = append(fake.productFilesForReleaseArgsForCall, struct {
+		arg1 string
+		arg2 int
+	}{arg1, arg2})
+	stub := fake.ProductFilesForReleaseStub
+	fakeReturns := fake.productFilesForReleaseReturns
+	fake.recordInvocation("ProductFilesForRelease", []interface{}{arg1, arg2})
+	fake.productFilesForReleaseMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakePivnetClient) ProductFilesForReleaseCallCount() int {
+	fake.productFilesForReleaseMutex.RLock()
+	defer fake.productFilesForReleaseMutex.RUnlock()
+	return len(fake.productFilesForReleaseArgsForCall)
+}
+
+func (fake *FakePivnetClient) ProductFilesForReleaseCalls(stub func(string, int) ([]pivnet.ProductFile, error)) {
+	fake.productFilesForReleaseMutex.Lock()
+	defer fake.productFilesForReleaseMutex.Unlock()
+	fake.ProductFilesForReleaseStub = stub
+}
+
+func (fake *FakePivnetClient) ProductFilesForReleaseArgsForCall(i int) (string, int) {
+	fake.productFilesForReleaseMutex.RLock()
+	defer fake.productFilesForReleaseMutex.RUnlock()
+	argsForCall := fake.productFilesForReleaseArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakePivnetClient) ProductFilesForReleaseReturns(result1 []pivnet.ProductFile, result2 error) {
+	fake.productFilesForReleaseMutex.Lock()
+	defer fake.productFilesForReleaseMutex.Unlock()
+	fake.ProductFilesForReleaseStub = nil
+	fake.productFilesForReleaseReturns = struct {
+		result1 []pivnet.ProductFile
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakePivnetClient) ProductFilesForReleaseReturnsOnCall(i int, result1 []pivnet.ProductFile, result2 error) {
+	fake.productFilesForReleaseMutex.Lock()
+	defer fake.productFilesForReleaseMutex.Unlock()
+	fake.ProductFilesForReleaseStub = nil
+	if fake.productFilesForReleaseReturnsOnCall == nil {
+		fake.productFilesForReleaseReturnsOnCall = make(map[int]struct {
+			result1 []pivnet.ProductFile
+			result2 error
+		})
+	}
+	fake.productFilesForReleaseReturnsOnCall[i] = struct {
+		result1 []pivnet.ProductFile
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakePivnetClient) ReleaseTypes() ([]pivnet.ReleaseType, error) {
@@ -160,6 +318,10 @@ func (fake *FakePivnetClient) ReleasesForProductSlugReturnsOnCall(i int, result1
 func (fake *FakePivnetClient) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.fileGroupsForReleaseMutex.RLock()
+	defer fake.fileGroupsForReleaseMutex.RUnlock()
+	fake.productFilesForReleaseMutex.RLock()
+	defer fake.productFilesForReleaseMutex.RUnlock()
 	fake.releaseTypesMutex.RLock()
 	defer fake.releaseTypesMutex.RUnlock()
 	fake.releasesForProductSlugMutex.RLock()

--- a/in/in_command.go
+++ b/in/in_command.go
@@ -112,18 +112,6 @@ func (c *InCommand) Run(input concourse.InRequest) (concourse.InResponse, error)
 		return concourse.InResponse{}, err
 	}
 
-	if fingerprint != "" {
-		actualFingerprint := release.SoftwareFilesUpdatedAt
-		if actualFingerprint != fingerprint {
-			return concourse.InResponse{}, fmt.Errorf(
-				"provided fingerprint: '%s' does not match actual fingerprint (from pivnet): '%s' - %s",
-				fingerprint,
-				actualFingerprint,
-				"pivnet does not support downloading old versions of a release",
-			)
-		}
-	}
-
 	c.logger.Info(fmt.Sprintf("Accepting EULA for release with ID: %d", release.ID))
 
 	err = c.pivnetClient.AcceptEULA(productSlug, release.ID)
@@ -148,6 +136,25 @@ func (c *InCommand) Run(input concourse.InRequest) (concourse.InResponse, error)
 	allProductFiles := releaseProductFiles
 	for _, fg := range fileGroups {
 		allProductFiles = append(allProductFiles, fg.ProductFiles...)
+	}
+
+	// Compute fingerprint from product files so we only trigger when files change (TNZ-22056)
+	fileMetadata := make([]versions.FileMetadata, 0, len(allProductFiles))
+	seen := make(map[int]bool)
+	for _, pf := range allProductFiles {
+		if !seen[pf.ID] {
+			seen[pf.ID] = true
+			fileMetadata = append(fileMetadata, versions.FileMetadata{ID: pf.ID, ReleasedAt: pf.ReleasedAt})
+		}
+	}
+	actualFingerprint := versions.FingerprintFromFileMetadata(fileMetadata)
+	if fingerprint != "" && actualFingerprint != fingerprint {
+		return concourse.InResponse{}, fmt.Errorf(
+			"provided fingerprint: '%s' does not match actual fingerprint (from product files): '%s' - %s",
+			fingerprint,
+			actualFingerprint,
+			"pivnet does not support downloading old versions of a release",
+		)
 	}
 
 	c.logger.Info("Getting artifact references")
@@ -194,7 +201,7 @@ func (c *InCommand) Run(input concourse.InRequest) (concourse.InResponse, error)
 
 	c.logger.Info("Creating metadata")
 
-	versionWithFingerprint, err := versions.CombineVersionAndFingerprint(version, fingerprint)
+	versionWithFingerprint, err := versions.CombineVersionAndFingerprint(version, actualFingerprint)
 
 	mdata := metadata.Metadata{
 		Release: &metadata.Release{

--- a/in/in_command_test.go
+++ b/in/in_command_test.go
@@ -49,7 +49,6 @@ var _ = Describe("In", func() {
 		upgradePathSpecifiers []pivnet.UpgradePathSpecifier
 
 		version                string
-		fingerprint            string
 		actualFingerprint      string
 		versionWithFingerprint string
 
@@ -100,8 +99,6 @@ var _ = Describe("In", func() {
 		artifactReferencesErr = nil
 
 		version = "C"
-		fingerprint = "fingerprint-0"
-		actualFingerprint = fingerprint
 
 		fileContentsSHA256s = []string{
 			"some-sha256 1234",
@@ -116,10 +113,6 @@ var _ = Describe("In", func() {
 			"some-md5 4567",
 			"some-md5 5678",
 		}
-
-		var err error
-		versionWithFingerprint, err = versions.CombineVersionAndFingerprint(version, fingerprint)
-		Expect(err).NotTo(HaveOccurred())
 
 		downloadFilepaths = []string{
 			"file-1234",
@@ -137,6 +130,7 @@ var _ = Describe("In", func() {
 				AWSObjectKey: downloadFilepaths[0],
 				FileType:     pivnet.FileTypeSoftware,
 				FileVersion:  "some-file-version 1234",
+				ReleasedAt:   "2021-01-01T00:00:00Z",
 				SHA256:       fileContentsSHA256s[0],
 				MD5:          fileContentsMD5s[0],
 				Links: &pivnet.Links{
@@ -151,6 +145,7 @@ var _ = Describe("In", func() {
 				AWSObjectKey: downloadFilepaths[1],
 				FileType:     pivnet.FileTypeSoftware,
 				FileVersion:  "some-file-version 3456",
+				ReleasedAt:   "2021-01-02T00:00:00Z",
 				SHA256:       fileContentsSHA256s[1],
 				MD5:          fileContentsMD5s[1],
 				Links: &pivnet.Links{
@@ -168,6 +163,7 @@ var _ = Describe("In", func() {
 				AWSObjectKey: downloadFilepaths[2],
 				FileType:     pivnet.FileTypeSoftware,
 				FileVersion:  "some-file-version 4567",
+				ReleasedAt:   "2021-01-03T00:00:00Z",
 				SHA256:       fileContentsSHA256s[2],
 				MD5:          fileContentsMD5s[2],
 				Links: &pivnet.Links{
@@ -185,6 +181,7 @@ var _ = Describe("In", func() {
 				AWSObjectKey: downloadFilepaths[3],
 				FileType:     pivnet.FileTypeSoftware,
 				FileVersion:  "some-file-version 5678",
+				ReleasedAt:   "2021-01-04T00:00:00Z",
 				SHA256:       fileContentsSHA256s[3],
 				MD5:          fileContentsMD5s[3],
 				Links: &pivnet.Links{
@@ -219,6 +216,28 @@ var _ = Describe("In", func() {
 			},
 		}
 
+		// Compute fingerprint from product files (TNZ-22056) to match in command behavior
+		seen := make(map[int]bool)
+		var fileMetadata []versions.FileMetadata
+		for _, pf := range releaseProductFiles {
+			if !seen[pf.ID] {
+				seen[pf.ID] = true
+				fileMetadata = append(fileMetadata, versions.FileMetadata{ID: pf.ID, ReleasedAt: pf.ReleasedAt})
+			}
+		}
+		for _, fg := range fileGroups {
+			for _, pf := range fg.ProductFiles {
+				if !seen[pf.ID] {
+					seen[pf.ID] = true
+					fileMetadata = append(fileMetadata, versions.FileMetadata{ID: pf.ID, ReleasedAt: pf.ReleasedAt})
+				}
+			}
+		}
+		actualFingerprint = versions.FingerprintFromFileMetadata(fileMetadata)
+		var err error
+		versionWithFingerprint, err = versions.CombineVersionAndFingerprint(version, actualFingerprint)
+		Expect(err).NotTo(HaveOccurred())
+
 		artifactReferences = []pivnet.ArtifactReference{
 			{
 				ID:                 101,
@@ -241,9 +260,8 @@ var _ = Describe("In", func() {
 		}
 
 		release = pivnet.Release{
-			Version:                version,
-			SoftwareFilesUpdatedAt: actualFingerprint,
-			ID:                     1234,
+			Version: version,
+			ID:      1234,
 			Links: &pivnet.Links{
 				ProductFiles: map[string]string{
 					"href": "some-file-path",
@@ -308,8 +326,6 @@ var _ = Describe("In", func() {
 	})
 
 	JustBeforeEach(func() {
-		release.SoftwareFilesUpdatedAt = actualFingerprint
-
 		fakePivnetClient.GetReleaseReturns(release, getReleaseErr)
 		fakePivnetClient.AcceptEULAReturns(acceptEULAErr)
 		fakePivnetClient.ProductFilesForReleaseReturns(releaseProductFiles, productFilesErr)
@@ -467,18 +483,17 @@ var _ = Describe("In", func() {
 
 	Context("when actual fingerprint is different than provided", func() {
 		BeforeEach(func() {
-			actualFingerprint = "different fingerprint"
+			// Request version with a fingerprint that won't match product files
+			inRequest.Version = concourse.Version{
+				ProductVersion: version + "#wrong-fingerprint",
+			}
 		})
 
 		It("returns the error", func() {
 			_, err := inCommand.Run(inRequest)
 			Expect(err).To(HaveOccurred())
-
-			Expect(err.Error()).To(MatchRegexp(
-				".*provided.*'%s'.*actual.*'%s'.*",
-				fingerprint,
-				actualFingerprint,
-			))
+			Expect(err.Error()).To(ContainSubstring("does not match actual fingerprint"))
+			Expect(err.Error()).To(ContainSubstring("product files"))
 		})
 	})
 

--- a/out/release/release_finalizer.go
+++ b/out/release/release_finalizer.go
@@ -40,6 +40,8 @@ func NewFinalizer(
 //counterfeiter:generate --fake-name FinalizerClient . finalizerClient
 type finalizerClient interface {
 	GetRelease(productSlug string, releaseVersion string) (pivnet.Release, error)
+	ProductFilesForRelease(productSlug string, releaseID int) ([]pivnet.ProductFile, error)
+	FileGroupsForRelease(productSlug string, releaseID int) ([]pivnet.FileGroup, error)
 }
 
 func (rf ReleaseFinalizer) Finalize(productSlug string, releaseVersion string) (concourse.OutResponse, error) {
@@ -48,7 +50,34 @@ func (rf ReleaseFinalizer) Finalize(productSlug string, releaseVersion string) (
 		return concourse.OutResponse{}, err
 	}
 
-	outputVersion, err := versions.CombineVersionAndFingerprint(newRelease.Version, newRelease.SoftwareFilesUpdatedAt)
+	// Compute fingerprint from product files so version only changes when files change (TNZ-22056)
+	releaseProductFiles, err := rf.pivnet.ProductFilesForRelease(productSlug, newRelease.ID)
+	if err != nil {
+		return concourse.OutResponse{}, err
+	}
+	fileGroups, err := rf.pivnet.FileGroupsForRelease(productSlug, newRelease.ID)
+	if err != nil {
+		return concourse.OutResponse{}, err
+	}
+	seen := make(map[int]bool)
+	var fileMetadata []versions.FileMetadata
+	for _, pf := range releaseProductFiles {
+		if !seen[pf.ID] {
+			seen[pf.ID] = true
+			fileMetadata = append(fileMetadata, versions.FileMetadata{ID: pf.ID, ReleasedAt: pf.ReleasedAt})
+		}
+	}
+	for _, fg := range fileGroups {
+		for _, pf := range fg.ProductFiles {
+			if !seen[pf.ID] {
+				seen[pf.ID] = true
+				fileMetadata = append(fileMetadata, versions.FileMetadata{ID: pf.ID, ReleasedAt: pf.ReleasedAt})
+			}
+		}
+	}
+	fingerprint := versions.FingerprintFromFileMetadata(fileMetadata)
+
+	outputVersion, err := versions.CombineVersionAndFingerprint(newRelease.Version, fingerprint)
 	if err != nil {
 		return concourse.OutResponse{}, err // this will never return an error
 	}

--- a/out/release/release_finalizer_test.go
+++ b/out/release/release_finalizer_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pivotal-cf/pivnet-resource/v3/metadata"
 	"github.com/pivotal-cf/pivnet-resource/v3/out/release"
 	"github.com/pivotal-cf/pivnet-resource/v3/out/release/releasefakes"
+	"github.com/pivotal-cf/pivnet-resource/v3/versions"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -51,7 +52,6 @@ var _ = Describe("ReleaseFinalizer", func() {
 				EULA: &pivnet.EULA{
 					Slug: "a_eula_slug",
 				},
-				SoftwareFilesUpdatedAt: "some-new-time",
 			}
 
 			mdata = metadata.Metadata{
@@ -77,14 +77,23 @@ var _ = Describe("ReleaseFinalizer", func() {
 			)
 
 			fakePivnet.GetReleaseReturns(pivnetRelease, releaseErr)
+			// Stub product files for file-based fingerprint (TNZ-22056)
+			fakePivnet.ProductFilesForReleaseReturns([]pivnet.ProductFile{
+				{ID: 1, ReleasedAt: "some-new-time"},
+			}, nil)
+			fakePivnet.FileGroupsForReleaseReturns([]pivnet.FileGroup{}, nil)
 		})
 
 		It("returns a final concourse out response", func() {
 			response, err := finalizer.Finalize(productSlug, pivnetRelease.Version)
 			Expect(err).NotTo(HaveOccurred())
 
+			expectedFingerprint := versions.FingerprintFromFileMetadata([]versions.FileMetadata{
+				{ID: 1, ReleasedAt: "some-new-time"},
+			})
+			expectedVersion, _ := versions.CombineVersionAndFingerprint("some-version", expectedFingerprint)
 			Expect(response.Version).To(Equal(concourse.Version{
-				ProductVersion: "some-version#some-new-time",
+				ProductVersion: expectedVersion,
 			}))
 
 			Expect(response.Metadata).To(ContainElement(concourse.Metadata{Name: "version", Value: "some-version"}))

--- a/out/release/releasefakes/finalizer_client.go
+++ b/out/release/releasefakes/finalizer_client.go
@@ -8,6 +8,20 @@ import (
 )
 
 type FinalizerClient struct {
+	FileGroupsForReleaseStub        func(string, int) ([]pivnet.FileGroup, error)
+	fileGroupsForReleaseMutex       sync.RWMutex
+	fileGroupsForReleaseArgsForCall []struct {
+		arg1 string
+		arg2 int
+	}
+	fileGroupsForReleaseReturns struct {
+		result1 []pivnet.FileGroup
+		result2 error
+	}
+	fileGroupsForReleaseReturnsOnCall map[int]struct {
+		result1 []pivnet.FileGroup
+		result2 error
+	}
 	GetReleaseStub        func(string, string) (pivnet.Release, error)
 	getReleaseMutex       sync.RWMutex
 	getReleaseArgsForCall []struct {
@@ -22,8 +36,87 @@ type FinalizerClient struct {
 		result1 pivnet.Release
 		result2 error
 	}
+	ProductFilesForReleaseStub        func(string, int) ([]pivnet.ProductFile, error)
+	productFilesForReleaseMutex       sync.RWMutex
+	productFilesForReleaseArgsForCall []struct {
+		arg1 string
+		arg2 int
+	}
+	productFilesForReleaseReturns struct {
+		result1 []pivnet.ProductFile
+		result2 error
+	}
+	productFilesForReleaseReturnsOnCall map[int]struct {
+		result1 []pivnet.ProductFile
+		result2 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FinalizerClient) FileGroupsForRelease(arg1 string, arg2 int) ([]pivnet.FileGroup, error) {
+	fake.fileGroupsForReleaseMutex.Lock()
+	ret, specificReturn := fake.fileGroupsForReleaseReturnsOnCall[len(fake.fileGroupsForReleaseArgsForCall)]
+	fake.fileGroupsForReleaseArgsForCall = append(fake.fileGroupsForReleaseArgsForCall, struct {
+		arg1 string
+		arg2 int
+	}{arg1, arg2})
+	stub := fake.FileGroupsForReleaseStub
+	fakeReturns := fake.fileGroupsForReleaseReturns
+	fake.recordInvocation("FileGroupsForRelease", []interface{}{arg1, arg2})
+	fake.fileGroupsForReleaseMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FinalizerClient) FileGroupsForReleaseCallCount() int {
+	fake.fileGroupsForReleaseMutex.RLock()
+	defer fake.fileGroupsForReleaseMutex.RUnlock()
+	return len(fake.fileGroupsForReleaseArgsForCall)
+}
+
+func (fake *FinalizerClient) FileGroupsForReleaseCalls(stub func(string, int) ([]pivnet.FileGroup, error)) {
+	fake.fileGroupsForReleaseMutex.Lock()
+	defer fake.fileGroupsForReleaseMutex.Unlock()
+	fake.FileGroupsForReleaseStub = stub
+}
+
+func (fake *FinalizerClient) FileGroupsForReleaseArgsForCall(i int) (string, int) {
+	fake.fileGroupsForReleaseMutex.RLock()
+	defer fake.fileGroupsForReleaseMutex.RUnlock()
+	argsForCall := fake.fileGroupsForReleaseArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FinalizerClient) FileGroupsForReleaseReturns(result1 []pivnet.FileGroup, result2 error) {
+	fake.fileGroupsForReleaseMutex.Lock()
+	defer fake.fileGroupsForReleaseMutex.Unlock()
+	fake.FileGroupsForReleaseStub = nil
+	fake.fileGroupsForReleaseReturns = struct {
+		result1 []pivnet.FileGroup
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FinalizerClient) FileGroupsForReleaseReturnsOnCall(i int, result1 []pivnet.FileGroup, result2 error) {
+	fake.fileGroupsForReleaseMutex.Lock()
+	defer fake.fileGroupsForReleaseMutex.Unlock()
+	fake.FileGroupsForReleaseStub = nil
+	if fake.fileGroupsForReleaseReturnsOnCall == nil {
+		fake.fileGroupsForReleaseReturnsOnCall = make(map[int]struct {
+			result1 []pivnet.FileGroup
+			result2 error
+		})
+	}
+	fake.fileGroupsForReleaseReturnsOnCall[i] = struct {
+		result1 []pivnet.FileGroup
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FinalizerClient) GetRelease(arg1 string, arg2 string) (pivnet.Release, error) {
@@ -91,11 +184,80 @@ func (fake *FinalizerClient) GetReleaseReturnsOnCall(i int, result1 pivnet.Relea
 	}{result1, result2}
 }
 
+func (fake *FinalizerClient) ProductFilesForRelease(arg1 string, arg2 int) ([]pivnet.ProductFile, error) {
+	fake.productFilesForReleaseMutex.Lock()
+	ret, specificReturn := fake.productFilesForReleaseReturnsOnCall[len(fake.productFilesForReleaseArgsForCall)]
+	fake.productFilesForReleaseArgsForCall = append(fake.productFilesForReleaseArgsForCall, struct {
+		arg1 string
+		arg2 int
+	}{arg1, arg2})
+	stub := fake.ProductFilesForReleaseStub
+	fakeReturns := fake.productFilesForReleaseReturns
+	fake.recordInvocation("ProductFilesForRelease", []interface{}{arg1, arg2})
+	fake.productFilesForReleaseMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FinalizerClient) ProductFilesForReleaseCallCount() int {
+	fake.productFilesForReleaseMutex.RLock()
+	defer fake.productFilesForReleaseMutex.RUnlock()
+	return len(fake.productFilesForReleaseArgsForCall)
+}
+
+func (fake *FinalizerClient) ProductFilesForReleaseCalls(stub func(string, int) ([]pivnet.ProductFile, error)) {
+	fake.productFilesForReleaseMutex.Lock()
+	defer fake.productFilesForReleaseMutex.Unlock()
+	fake.ProductFilesForReleaseStub = stub
+}
+
+func (fake *FinalizerClient) ProductFilesForReleaseArgsForCall(i int) (string, int) {
+	fake.productFilesForReleaseMutex.RLock()
+	defer fake.productFilesForReleaseMutex.RUnlock()
+	argsForCall := fake.productFilesForReleaseArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FinalizerClient) ProductFilesForReleaseReturns(result1 []pivnet.ProductFile, result2 error) {
+	fake.productFilesForReleaseMutex.Lock()
+	defer fake.productFilesForReleaseMutex.Unlock()
+	fake.ProductFilesForReleaseStub = nil
+	fake.productFilesForReleaseReturns = struct {
+		result1 []pivnet.ProductFile
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FinalizerClient) ProductFilesForReleaseReturnsOnCall(i int, result1 []pivnet.ProductFile, result2 error) {
+	fake.productFilesForReleaseMutex.Lock()
+	defer fake.productFilesForReleaseMutex.Unlock()
+	fake.ProductFilesForReleaseStub = nil
+	if fake.productFilesForReleaseReturnsOnCall == nil {
+		fake.productFilesForReleaseReturnsOnCall = make(map[int]struct {
+			result1 []pivnet.ProductFile
+			result2 error
+		})
+	}
+	fake.productFilesForReleaseReturnsOnCall[i] = struct {
+		result1 []pivnet.ProductFile
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FinalizerClient) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.fileGroupsForReleaseMutex.RLock()
+	defer fake.fileGroupsForReleaseMutex.RUnlock()
 	fake.getReleaseMutex.RLock()
 	defer fake.getReleaseMutex.RUnlock()
+	fake.productFilesForReleaseMutex.RLock()
+	defer fake.productFilesForReleaseMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/versions/versions.go
+++ b/versions/versions.go
@@ -1,13 +1,41 @@
 package versions
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"sort"
 	"strings"
 )
 
 const (
 	fingerprintDelimiter = "#"
 )
+
+// FileMetadata represents a product file's identity and release time for fingerprinting.
+// Used to compute a version fingerprint that only changes when product files change.
+type FileMetadata struct {
+	ID         int
+	ReleasedAt string
+}
+
+// FingerprintFromFileMetadata returns a deterministic fingerprint from product file metadata.
+// Only changes when the set of files or their ReleasedAt values change (not on metadata-only updates).
+func FingerprintFromFileMetadata(files []FileMetadata) string {
+	if len(files) == 0 {
+		return ""
+	}
+	// Copy and sort by ID for deterministic output
+	sorted := make([]FileMetadata, len(files))
+	copy(sorted, files)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].ID < sorted[j].ID })
+	var b strings.Builder
+	for _, f := range sorted {
+		b.WriteString(fmt.Sprintf("%d:%s\n", f.ID, f.ReleasedAt))
+	}
+	sum := sha256.Sum256([]byte(b.String()))
+	return hex.EncodeToString(sum[:])
+}
 
 func Since(versions []string, since string) ([]string, error) {
 	for i, v := range versions {

--- a/versions/versions_test.go
+++ b/versions/versions_test.go
@@ -144,4 +144,41 @@ var _ = Describe("Versions", func() {
 			})
 		})
 	})
+
+	Describe("FingerprintFromFileMetadata", func() {
+		It("returns empty string for empty input", func() {
+			Expect(versions.FingerprintFromFileMetadata(nil)).To(Equal(""))
+			Expect(versions.FingerprintFromFileMetadata([]versions.FileMetadata{})).To(Equal(""))
+		})
+
+		It("returns deterministic fingerprint for one file", func() {
+			fp := versions.FingerprintFromFileMetadata([]versions.FileMetadata{
+				{ID: 1, ReleasedAt: "2021-01-01T00:00:00Z"},
+			})
+			Expect(fp).To(HaveLen(64)) // SHA256 hex
+			Expect(versions.FingerprintFromFileMetadata([]versions.FileMetadata{
+				{ID: 1, ReleasedAt: "2021-01-01T00:00:00Z"},
+			})).To(Equal(fp))
+		})
+
+		It("returns same fingerprint for same files in different order", func() {
+			files1 := []versions.FileMetadata{
+				{ID: 1, ReleasedAt: "a"},
+				{ID: 2, ReleasedAt: "b"},
+			}
+			files2 := []versions.FileMetadata{
+				{ID: 2, ReleasedAt: "b"},
+				{ID: 1, ReleasedAt: "a"},
+			}
+			Expect(versions.FingerprintFromFileMetadata(files1)).To(Equal(versions.FingerprintFromFileMetadata(files2)))
+		})
+
+		It("returns different fingerprint when file IDs or ReleasedAt differ", func() {
+			fp1 := versions.FingerprintFromFileMetadata([]versions.FileMetadata{{ID: 1, ReleasedAt: "a"}})
+			fp2 := versions.FingerprintFromFileMetadata([]versions.FileMetadata{{ID: 2, ReleasedAt: "a"}})
+			fp3 := versions.FingerprintFromFileMetadata([]versions.FileMetadata{{ID: 1, ReleasedAt: "b"}})
+			Expect(fp1).NotTo(Equal(fp2))
+			Expect(fp1).NotTo(Equal(fp3))
+		})
+	})
 })


### PR DESCRIPTION
[Alternate implementation to PR#152]

- Add versions.FingerprintFromFileMetadata() to compute fingerprint from product file IDs and ReleasedAt
- Check: fetch ProductFilesForRelease + FileGroupsForRelease per release, use computed fingerprint instead of SoftwareFilesUpdatedAt
- In: compute fingerprint from product files, validate and emit it (no longer use release.SoftwareFilesUpdatedAt)
- Out/finalizer: compute fingerprint from product files for output version
- Update tests and regenerate fakes

Alternate implementation to PR #152 (product_version_only mode). This approach keeps version#fingerprint semantics but makes the fingerprint reflect only file changes, so pipelines trigger when files change and not on metadata-only updates.

