### PR TITLE
Removing version fingerprint that is generated using "software_files_updated_at" property

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,17 @@ See [example pipeline configurations](https://github.com/pivotal-cf/pivnet-resou
 Discovers all versions of the provided product.
 Returned versions are optionally filtered and ordered by the `source` configuration.
 
+Each version’s `product_version` is the **release version string** from Tanzu Network (for example `2.0.2`). The resource does **not** append a timestamp or other suffix, so metadata-only changes to a release do not surface as a new Concourse version when that semver is unchanged.
+
+If you previously pinned versions from an older resource image, they may look like `2.0.2#2017-03-23T12:00:00.000Z`. That form is still accepted as input to `check`; only the part before `#` is used when comparing and matching releases.
+
 ### `in`: download the product from Tanzu Network
 
 Downloads the provided product from Tanzu Network. You will be required to accept a
 EULA for any product you're downloading for the first time, as well as if the terms and
 conditions associated with the product change.
+
+The `version` in the response and the `version` file written to the task directory contain the **release version string only** (no `#…` suffix). You may still pass a legacy `version#timestamp` pin from an older pipeline; the suffix is ignored when resolving the release.
 
 The metadata for the product is written to both `metadata.json` and
 `metadata.yaml` in the working directory (typically `/tmp/build/get`).
@@ -175,6 +181,8 @@ jobs:
 ### `out`: upload a product to Tanzu Network
 
 Creates a new release on Tanzu Network with the provided version and metadata.
+
+The `version` returned from `out` may still include a `#…` suffix derived from Tanzu Network. That applies only to **`out`**; **`check`** and **`in`** use the release version string without that suffix (see above).
 
 It can also upload one or more files to Tanzu Network bucket and calculate the
 MD5 checksum locally for each file in order to add MD5 checksum to the file
@@ -295,10 +303,10 @@ in your `check-resource` command for it to work properly. Eg:
 ```
 fly -t pivnet check-resource \
   --resource pivnet-resource-bug-152616708/binary-buildpack \
-  --from product_version:Binary\ 1.0.11#2017-03-23T13:57:51.214Z
+  --from product_version:Binary\ 1.0.11
 ```
 
-In this example we escaped the space between "Binary" and "1.0.11".
+In this example we escaped the space between "Binary" and "1.0.11". If you are continuing from an older pinned version, `--from` may still use the legacy form `Binary\ 1.0.11#2017-03-23T13:57:51.214Z`; the resource accepts it, but `check` / `in` treat the release as identified by the part before `#`.
 
 ## Integration environment
 

--- a/check/check_command.go
+++ b/check/check_command.go
@@ -116,7 +116,6 @@ func (c *CheckCommand) Run(input concourse.CheckRequest) (concourse.CheckRespons
 
 	vs, err := releaseVersions(releases)
 	if err != nil {
-		// Untested because versions.CombineVersionAndFingerprint cannot be forced to return an error.
 		return concourse.CheckResponse{}, err
 	}
 
@@ -126,7 +125,8 @@ func (c *CheckCommand) Run(input concourse.CheckRequest) (concourse.CheckRespons
 
 	c.logger.Info("Gathering new versions")
 
-	newVersions, err := versions.Since(vs, input.Version.ProductVersion)
+	sinceVersion := versions.VersionOnly(input.Version.ProductVersion)
+	newVersions, err := versions.Since(vs, sinceVersion)
 	if err != nil {
 		// Untested because versions.Since cannot be forced to return an error.
 		return nil, err
@@ -214,15 +214,14 @@ func containsString(strings []string, str string) bool {
 }
 
 func releaseVersions(releases []pivnet.Release) ([]string, error) {
-	releaseVersions := make([]string, len(releases))
-
-	var err error
-	for i, r := range releases {
-		releaseVersions[i], err = versions.CombineVersionAndFingerprint(r.Version, r.SoftwareFilesUpdatedAt)
-		if err != nil {
-			return nil, err
+	seen := make(map[string]bool)
+	var result []string
+	for _, r := range releases {
+		if seen[r.Version] {
+			continue
 		}
+		seen[r.Version] = true
+		result = append(result, r.Version)
 	}
-
-	return releaseVersions, nil
+	return result, nil
 }

--- a/check/check_command_test.go
+++ b/check/check_command_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/pivotal-cf/pivnet-resource/v3/check"
 	"github.com/pivotal-cf/pivnet-resource/v3/check/checkfakes"
 	"github.com/pivotal-cf/pivnet-resource/v3/concourse"
-	"github.com/pivotal-cf/pivnet-resource/v3/versions"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -30,7 +29,7 @@ var _ = Describe("Check", func() {
 		checkRequest concourse.CheckRequest
 		checkCommand *check.CheckCommand
 
-		versionsWithFingerprints []string
+		expectedVersions []string // product version only, same order as releaseVersions from check
 
 		releaseTypes    []pivnet.ReleaseType
 		releaseTypesErr error
@@ -86,11 +85,9 @@ var _ = Describe("Check", func() {
 			},
 		}
 
-		versionsWithFingerprints = make([]string, len(allReleases))
+		expectedVersions = make([]string, len(allReleases))
 		for i, r := range allReleases {
-			v, err := versions.CombineVersionAndFingerprint(r.Version, r.SoftwareFilesUpdatedAt)
-			Expect(err).NotTo(HaveOccurred())
-			versionsWithFingerprints[i] = v
+			expectedVersions[i] = r.Version
 		}
 
 		filteredReleases = allReleases
@@ -139,10 +136,8 @@ var _ = Describe("Check", func() {
 		response, err := checkCommand.Run(checkRequest)
 		Expect(err).NotTo(HaveOccurred())
 
-		expectedVersionWithFingerprint := versionsWithFingerprints[0]
-
 		Expect(response).To(HaveLen(1))
-		Expect(response[0].ProductVersion).To(Equal(expectedVersionWithFingerprint))
+		Expect(response[0].ProductVersion).To(Equal(expectedVersions[0]))
 	})
 
 	Context("when no releases are returned", func() {
@@ -220,10 +215,8 @@ var _ = Describe("Check", func() {
 	Describe("when a version is provided", func() {
 		Context("when the version is the latest", func() {
 			BeforeEach(func() {
-				versionWithFingerprint := versionsWithFingerprints[0]
-
 				checkRequest.Version = concourse.Version{
-					ProductVersion: versionWithFingerprint,
+					ProductVersion: expectedVersions[0], // 1.2.3
 				}
 			})
 
@@ -231,19 +224,15 @@ var _ = Describe("Check", func() {
 				response, err := checkCommand.Run(checkRequest)
 				Expect(err).NotTo(HaveOccurred())
 
-				versionWithFingerprintA := versionsWithFingerprints[0]
-
 				Expect(response).To(HaveLen(1))
-				Expect(response[0].ProductVersion).To(Equal(versionWithFingerprintA))
+				Expect(response[0].ProductVersion).To(Equal(expectedVersions[0]))
 			})
 		})
 
 		Context("when the version is not the latest", func() {
 			BeforeEach(func() {
-				versionWithFingerprint := versionsWithFingerprints[2] // 1.2.4#time3
-
 				checkRequest.Version = concourse.Version{
-					ProductVersion: versionWithFingerprint,
+					ProductVersion: expectedVersions[2], // 1.2.4
 				}
 			})
 
@@ -251,15 +240,32 @@ var _ = Describe("Check", func() {
 				response, err := checkCommand.Run(checkRequest)
 				Expect(err).NotTo(HaveOccurred())
 
-				versionWithFingerprintA := versionsWithFingerprints[0] // 1.2.3#time1
-				versionWithFingerprintB := versionsWithFingerprints[1] // 2.3.4#time2
-				versionWithFingerprintC := versionsWithFingerprints[2] // 1.2.4#time3
-
+				// vs order is 1.2.3, 2.3.4, 1.2.4; Since(1.2.4) then Reverse => 1.2.4, 2.3.4, 1.2.3
 				Expect(response).To(HaveLen(3))
-				Expect(response[0].ProductVersion).To(Equal(versionWithFingerprintC))
-				Expect(response[1].ProductVersion).To(Equal(versionWithFingerprintB))
-				Expect(response[2].ProductVersion).To(Equal(versionWithFingerprintA))
+				Expect(response[0].ProductVersion).To(Equal("1.2.4"))
+				Expect(response[1].ProductVersion).To(Equal("2.3.4"))
+				Expect(response[2].ProductVersion).To(Equal("1.2.3"))
 			})
+		})
+	})
+
+	Context("when multiple releases have the same product version", func() {
+		BeforeEach(func() {
+			allReleases = []pivnet.Release{
+				{ID: 1, Version: "1.2.3", ReleaseType: releaseTypes[0], SoftwareFilesUpdatedAt: "time1"},
+				{ID: 2, Version: "1.2.3", ReleaseType: releaseTypes[1], SoftwareFilesUpdatedAt: "time2"},
+				{ID: 3, Version: "2.0.0", ReleaseType: releaseTypes[2], SoftwareFilesUpdatedAt: "time3"},
+			}
+			expectedVersions = []string{"1.2.3", "2.0.0"}
+			filteredReleases = allReleases
+		})
+
+		It("deduplicates by product version and returns one entry per version", func() {
+			response, err := checkCommand.Run(checkRequest)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(response).To(HaveLen(1))
+			Expect(response[0].ProductVersion).To(Equal("1.2.3"))
 		})
 	})
 
@@ -274,10 +280,8 @@ var _ = Describe("Check", func() {
 			response, err := checkCommand.Run(checkRequest)
 			Expect(err).NotTo(HaveOccurred())
 
-			versionWithFingerprintC := versionsWithFingerprints[1]
-
 			Expect(response).To(HaveLen(1))
-			Expect(response[0].ProductVersion).To(Equal(versionWithFingerprintC))
+			Expect(response[0].ProductVersion).To(Equal(expectedVersions[1])) // 2.3.4
 		})
 
 		Context("when the release type is invalid", func() {
@@ -325,10 +329,8 @@ var _ = Describe("Check", func() {
 			response, err := checkCommand.Run(checkRequest)
 			Expect(err).NotTo(HaveOccurred())
 
-			versionWithFingerprintC := versionsWithFingerprints[1]
-
 			Expect(response).To(HaveLen(1))
-			Expect(response[0].ProductVersion).To(Equal(versionWithFingerprintC))
+			Expect(response[0].ProductVersion).To(Equal(expectedVersions[1])) // 2.3.4
 		})
 
 		Context("when filtering returns an error", func() {
@@ -360,7 +362,7 @@ var _ = Describe("Check", func() {
 			}
 
 			checkRequest.Version = concourse.Version{
-				ProductVersion: versionsWithFingerprints[0], // 1.2.3#time1
+				ProductVersion: "1.2.3",
 			}
 
 			fakeSorter.SortBySemverReturns(semverOrderedReleases, nil)
@@ -370,10 +372,11 @@ var _ = Describe("Check", func() {
 			response, err := checkCommand.Run(checkRequest)
 			Expect(err).NotTo(HaveOccurred())
 
+			// vs = 2.3.4, 1.2.4, 1.2.3; Since(1.2.3) then Reverse => 1.2.3, 1.2.4, 2.3.4
 			Expect(response).To(HaveLen(3))
-			Expect(response[0].ProductVersion).To(Equal(versionsWithFingerprints[0]))
-			Expect(response[1].ProductVersion).To(Equal(versionsWithFingerprints[2]))
-			Expect(response[2].ProductVersion).To(Equal(versionsWithFingerprints[1]))
+			Expect(response[0].ProductVersion).To(Equal("1.2.3"))
+			Expect(response[1].ProductVersion).To(Equal("1.2.4"))
+			Expect(response[2].ProductVersion).To(Equal("2.3.4"))
 
 			Expect(fakeSorter.SortBySemverCallCount()).To(Equal(1))
 		})
@@ -413,7 +416,7 @@ var _ = Describe("Check", func() {
 			}
 
 			checkRequest.Version = concourse.Version{
-				ProductVersion: versionsWithFingerprints[0], // 1.2.3#time1
+				ProductVersion: "1.2.3",
 			}
 
 			fakeSorter.SortByLastUpdatedReturns(releases, nil)

--- a/in/in_command.go
+++ b/in/in_command.go
@@ -94,12 +94,7 @@ func NewInCommand(
 func (c *InCommand) Run(input concourse.InRequest) (concourse.InResponse, error) {
 	productSlug := input.Source.ProductSlug
 
-	version, fingerprint, err := versions.SplitIntoVersionAndFingerprint(input.Version.ProductVersion)
-	if err != nil {
-		c.logger.Info("Parsing of fingerprint failed; continuing without it")
-		version = input.Version.ProductVersion
-		fingerprint = ""
-	}
+	version := versions.VersionOnly(input.Version.ProductVersion)
 
 	c.logger.Info(fmt.Sprintf(
 		"Getting release for product slug: '%s' and product version: '%s'",
@@ -110,18 +105,6 @@ func (c *InCommand) Run(input concourse.InRequest) (concourse.InResponse, error)
 	release, err := c.pivnetClient.GetRelease(productSlug, version)
 	if err != nil {
 		return concourse.InResponse{}, err
-	}
-
-	if fingerprint != "" {
-		actualFingerprint := release.SoftwareFilesUpdatedAt
-		if actualFingerprint != fingerprint {
-			return concourse.InResponse{}, fmt.Errorf(
-				"provided fingerprint: '%s' does not match actual fingerprint (from pivnet): '%s' - %s",
-				fingerprint,
-				actualFingerprint,
-				"pivnet does not support downloading old versions of a release",
-			)
-		}
 	}
 
 	c.logger.Info(fmt.Sprintf("Accepting EULA for release with ID: %d", release.ID))
@@ -194,7 +177,8 @@ func (c *InCommand) Run(input concourse.InRequest) (concourse.InResponse, error)
 
 	c.logger.Info("Creating metadata")
 
-	versionWithFingerprint, err := versions.CombineVersionAndFingerprint(version, fingerprint)
+	// Emit product version only (no fingerprint)
+	versionToWrite := version
 
 	mdata := metadata.Metadata{
 		Release: &metadata.Release{
@@ -306,7 +290,7 @@ func (c *InCommand) Run(input concourse.InRequest) (concourse.InResponse, error)
 
 	c.logger.Info("Writing metadata files")
 
-	err = c.fileWriter.WriteVersionFile(versionWithFingerprint)
+	err = c.fileWriter.WriteVersionFile(versionToWrite)
 	if err != nil {
 		return concourse.InResponse{}, err
 	}
@@ -325,7 +309,7 @@ func (c *InCommand) Run(input concourse.InRequest) (concourse.InResponse, error)
 
 	out := concourse.InResponse{
 		Version: concourse.Version{
-			ProductVersion: versionWithFingerprint,
+			ProductVersion: versionToWrite,
 		},
 		Metadata: concourseMetadata,
 	}

--- a/in/in_command.go
+++ b/in/in_command.go
@@ -34,7 +34,7 @@ type fileSummer interface {
 type fileWriter interface {
 	WriteMetadataJSONFile(mdata metadata.Metadata) error
 	WriteMetadataYAMLFile(mdata metadata.Metadata) error
-	WriteVersionFile(versionWithFingerprint string) error
+	WriteVersionFile(versionToWrite string) error
 }
 
 //counterfeiter:generate --fake-name FakePivnetClient . pivnetClient

--- a/in/in_command_test.go
+++ b/in/in_command_test.go
@@ -367,12 +367,18 @@ var _ = Describe("In", func() {
 		)
 	})
 
-	It("invokes the version file writer with downloaded version and fingerprint", func() {
+	It("invokes the version file writer with product version only", func() {
 		_, err := inCommand.Run(inRequest)
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(fakeFileWriter.WriteVersionFileCallCount()).To(Equal(1))
-		Expect(fakeFileWriter.WriteVersionFileArgsForCall(0)).To(Equal(versionWithFingerprint))
+		Expect(fakeFileWriter.WriteVersionFileArgsForCall(0)).To(Equal(version))
+	})
+
+	It("returns response with product version only", func() {
+		response, err := inCommand.Run(inRequest)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(response.Version.ProductVersion).To(Equal(version))
 	})
 
 	It("invokes the json metadata file writer with correct metadata", func() {
@@ -446,9 +452,24 @@ var _ = Describe("In", func() {
 			}
 		})
 
-		It("returns without error (does not compare against actual fingerprint)", func() {
+		It("returns without error and writes version only", func() {
 			_, err := inCommand.Run(inRequest)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(fakeFileWriter.WriteVersionFileArgsForCall(0)).To(Equal(version))
+		})
+	})
+
+	Context("when version is provided with fingerprint (legacy format)", func() {
+		BeforeEach(func() {
+			inRequest.Version = concourse.Version{
+				ProductVersion: versionWithFingerprint,
+			}
+		})
+
+		It("strips fingerprint and writes version only", func() {
+			_, err := inCommand.Run(inRequest)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(fakeFileWriter.WriteVersionFileArgsForCall(0)).To(Equal(version))
 		})
 	})
 
@@ -462,23 +483,6 @@ var _ = Describe("In", func() {
 			Expect(err).To(HaveOccurred())
 
 			Expect(err).To(Equal(getReleaseErr))
-		})
-	})
-
-	Context("when actual fingerprint is different than provided", func() {
-		BeforeEach(func() {
-			actualFingerprint = "different fingerprint"
-		})
-
-		It("returns the error", func() {
-			_, err := inCommand.Run(inRequest)
-			Expect(err).To(HaveOccurred())
-
-			Expect(err.Error()).To(MatchRegexp(
-				".*provided.*'%s'.*actual.*'%s'.*",
-				fingerprint,
-				actualFingerprint,
-			))
 		})
 	})
 

--- a/versions/versions.go
+++ b/versions/versions.go
@@ -46,3 +46,10 @@ func CombineVersionAndFingerprint(version string, fingerprint string) (string, e
 func combineVersionAndFingerprint(version string, fingerprint string) string {
 	return fmt.Sprintf("%s%s%s", version, fingerprintDelimiter, fingerprint)
 }
+
+// VersionOnly returns the product version part of a version string, stripping any
+// fingerprint after the delimiter. If there is no delimiter, the full string is returned.
+func VersionOnly(versionWithOptionalFingerprint string) string {
+	split := strings.SplitN(versionWithOptionalFingerprint, fingerprintDelimiter, 2)
+	return split[0]
+}

--- a/versions/versions_test.go
+++ b/versions/versions_test.go
@@ -144,4 +144,18 @@ var _ = Describe("Versions", func() {
 			})
 		})
 	})
+
+	Describe("VersionOnly", func() {
+		It("returns only the version part when fingerprint is present", func() {
+			Expect(versions.VersionOnly("1.2.3#2024-01-15T12:00:00Z")).To(Equal("1.2.3"))
+		})
+
+		It("returns the full string when no delimiter is present", func() {
+			Expect(versions.VersionOnly("1.2.3")).To(Equal("1.2.3"))
+		})
+
+		It("returns the version part when fingerprint contains the delimiter", func() {
+			Expect(versions.VersionOnly("1.2.3#fingerprint-with#hash")).To(Equal("1.2.3"))
+		})
+	})
 })


### PR DESCRIPTION
The property "software_files_updated_at" gets updated any time there is a metadata change. The former practice of updating release build files in-place once a release is completed is not longer part of the release process. It is no longer valid to rely on that property to find out if release files were updated. Hence the property "software_files_updated_at" is useful only to find if there are metadata updates. Since product download shoud not trigger with metadata updates, using "software_files_updated_at" property to fingerprint release versions, this PR is removing the version fingerprint altogether from "check" and "in" commands.